### PR TITLE
Add FastAPI endpoint and updated requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI, UploadFile, File
+import numpy as np
+from PIL import Image
+import tensorflow as tf
+import joblib
+import io
+
+app = FastAPI()
+model = tf.keras.models.load_model("maize_model2.h5")
+label_encoder = joblib.load("label_encoder.pkl")
+
+def preprocess(image_bytes):
+    image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    image = image.resize((64, 64))
+    image_array = np.array(image) / 255.0
+    return np.expand_dims(image_array, axis=0)
+
+@app.post("/predict")
+async def predict(file: UploadFile = File(...)):
+    image_bytes = await file.read()
+    input_tensor = preprocess(image_bytes)
+    preds = model.predict(input_tensor)
+    label = label_encoder.inverse_transform([np.argmax(preds)])[0]
+    confidence = float(np.max(preds))
+    return {"label": label, "confidence": round(confidence, 3)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,10 @@ opencv-python-headless
 pillow
 scikit-learn
 tensorflow
+
+fastapi
+uvicorn
+tensorflow
+pillow
+joblib
+numpy


### PR DESCRIPTION
@Jenn-mawia 
This PR adds a new main.py file exposing our trained maize pest classification model as a /predict API using FastAPI. Changes include:

main.py to serve the model predictions

Updates to requirements.txt to include FastAPI, TensorFlow, etc.
Test example:
curl -X POST http://localhost:8000/predict -F "file=@your_image.jpg"